### PR TITLE
README.mdにバッヂを追記した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # cwf
 ターミナル上に文字で天気を知ることができるCLI（コマンドラインインターフェース）
+[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
+[![Coverage Status](https://coveralls.io/repos/github/Moppi0725/cwf/badge.svg?branch=main)](https://coveralls.io/github/Moppi0725/cwf?branch=main)
+[![codebeat badge](https://codebeat.co/badges/92a1e448-567f-4861-9a57-e74127d569b1)](https://codebeat.co/projects/github-com-moppi0725-cwf-main)
+[![Go Report Card](https://goreportcard.com/badge/github.com/moppi0725/cwf)](https://goreportcard.com/report/github.com/moppi0725/cwf)
 ## 概要
 作業中のターミナル上に天気予報を表示するソフトウェア．  
 課題や仕事の合間に帰る時間が知りたくなったり，  


### PR DESCRIPTION
Coveralls, Codebeat, go report cardのバッヂを追記しました．